### PR TITLE
Fix conditional test dependencies' version constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ exclude =
 testing =
 	# upstream
 	pytest >= 4.6
-	pytest-checkdocs >= 2.4; python_version > "3"
+	pytest-checkdocs >= 2.4; python_version >= "3"
 	pytest-flake8
 	# python_implementation: workaround for jaraco/skeleton#22
 	# python_version: workaround for python/typed_ast#156
@@ -41,8 +41,8 @@ testing =
 	pytest-cov
 	# python_implementation: workaround for jaraco/skeleton#22
 	# python_version: workaround for python/typed_ast#156
-	pytest-mypy; python_implementation != "PyPy" and python_version < "3.10" and python_version > "3"
-	pytest-enabler >= 1.0.1; python_version > "3"
+	pytest-mypy; python_implementation != "PyPy" and python_version < "3.10" and python_version >= "3"
+	pytest-enabler >= 1.0.1; python_version >= "3"
 
 	# local
 


### PR DESCRIPTION
See https://github.com/python-poetry/poetry/issues/3893

Poetry interprets `python_version > "3"` as `python_version >= "4"` and errors.